### PR TITLE
Gate maven deploy on non-snapshot version

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -45,6 +45,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - uses: s4u/maven-settings-action@v4.0.0
+        if: steps.version-check.outputs.should_publish == 'true'
         with:
           servers: |
             [{
@@ -59,6 +60,7 @@ jobs:
             }]
 
       - name: Import GPG key
+        if: steps.version-check.outputs.should_publish == 'true'
         uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -66,7 +68,15 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
 
-      - name: Build & Deploy
+      - name: Build & Verify (Snapshot)
+        if: steps.version-check.outputs.should_publish != 'true'
+        run: >
+          ./mvnw verify
+          -Dci.buildNumber=$GITHUB_RUN_NUMBER
+          -U -B $MAVEN_OPTS
+
+      - name: Build & Deploy (Release)
+        if: steps.version-check.outputs.should_publish == 'true'
         run: >
           ./mvnw deploy
           -Dci.buildNumber=$GITHUB_RUN_NUMBER


### PR DESCRIPTION
## Summary
- Master builds of a `-SNAPSHOT` version now run `./mvnw verify` only instead of `./mvnw deploy`
- The `maven-settings-action` and `Import GPG key` steps are skipped for snapshot builds, so they no longer depend on the `OSSRH_*`/`GPG_*` secrets
- Release (non-snapshot) versions keep the existing `./mvnw deploy -Prelease,release-central,gpg` publish flow, based on the `should_publish` output of the existing version check step