### PR TITLE
6: Only deploy artifacts when releasing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "org.openwms:org.openwms.parent"

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -4,7 +4,15 @@ on:
     branches-ignore:
       - master
       - gh-pages
-      - 'release/**'
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
@@ -13,22 +21,34 @@ jobs:
   build_job:
     runs-on: ubuntu-latest
     name: Build & Test Microservice
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          distribution: liberica
+          distribution: 'liberica'
           java-version: 25
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: maven
+
       - name: Build
         run: >
-          ./mvnw verify
+          ./mvnw clean verify
           -Dci.buildNumber=$GITHUB_RUN_NUMBER
-          -U -B $MAVEN_OPTS
+          -U -B
+
+      - name: Upload test reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: target/surefire-reports
+          retention-days: 7
+
+      - name: Validate Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: interface21/org.openwms.core.admin:branch

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -4,6 +4,14 @@ on:
   push:
     branches: [ master ]
 
+# contents: write is required by scm-publish to push the Maven site to gh-pages
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
@@ -11,25 +19,18 @@ jobs:
   build_job:
     runs-on: ubuntu-latest
     name: Build & Test Microservice
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          distribution: liberica
+          distribution: 'liberica'
           java-version: 25
-
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: maven
 
       - name: Check version
-        if: github.event_name != 'pull_request'
         id: version-check
         run: |
           VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
@@ -59,6 +60,7 @@ jobs:
             }]
 
       - name: Import GPG key
+        if: steps.version-check.outputs.should_publish == 'true'
         uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -66,15 +68,30 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
 
-      - name: Build & Deploy
+      - name: Build
+        if: steps.version-check.outputs.should_publish == 'false'
         run: >
-          ./mvnw deploy
+          ./mvnw clean verify
+          -Dci.buildNumber=$GITHUB_RUN_NUMBER
+          -U -B $MAVEN_OPTS
+
+      - name: Build & Deploy to Maven Central
+        if: steps.version-check.outputs.should_publish == 'true'
+        run: >
+          ./mvnw clean deploy
           -Dci.buildNumber=$GITHUB_RUN_NUMBER
           -U -B -Prelease,release-central,gpg $MAVEN_OPTS
 
+      - name: Upload test reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: target/surefire-reports
+          retention-days: 7
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -84,21 +101,23 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build & Push Images (amd64/arm64)
+      - name: Push Image
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: interface21/org.openwms.core.admin:${{ steps.version-check.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Install tools
         if: steps.version-check.outputs.should_publish == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install graphviz gsfonts graphviz-doc
-          git config --global user.email "ci@example.com"
-          git config --global user.name "CI Server"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Site
         if: steps.version-check.outputs.should_publish == 'true'

--- a/scripts/docker_build
+++ b/scripts/docker_build
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker build --platform linux/amd64 -t interface21/org.openwms.core.admin:$1 .
+docker build --platform linux/amd64 -t interface21/org.openwms.core.admin:${1:-latest} .

--- a/scripts/docker_build_arm64
+++ b/scripts/docker_build_arm64
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker build --platform linux/amd64 -t interface21/org.openwms.core.admin:${1:-latest} .
+docker build --platform linux/arm64 -t interface21/org.openwms.core.admin:${1:-latest} .

--- a/scripts/docker_build_arm64
+++ b/scripts/docker_build_arm64
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build --platform linux/amd64 -t interface21/org.openwms.core.admin:${1:-latest} .

--- a/src/main/java/org/openwms/core/admin/AdminStarter.java
+++ b/src/main/java/org/openwms/core/admin/AdminStarter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2025 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/openwms/core/admin/app/AdminOtlpConfiguration.java
+++ b/src/main/java/org/openwms/core/admin/app/AdminOtlpConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2025 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/openwms/core/admin/app/AdminSecurityConfiguration.java
+++ b/src/main/java/org/openwms/core/admin/app/AdminSecurityConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2025 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/openwms/core/admin/app/package-info.java
+++ b/src/main/java/org/openwms/core/admin/app/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * This package contains Spring lifecycle classes.
+ */
+package org.openwms.services.app;

--- a/src/main/java/org/openwms/core/admin/app/package-info.java
+++ b/src/main/java/org/openwms/core/admin/app/package-info.java
@@ -1,4 +1,4 @@
 /**
  * This package contains Spring lifecycle classes.
  */
-package org.openwms.services.app;
+package org.openwms.core.admin.app;

--- a/src/main/resources/META-INF/LICENSE
+++ b/src/main/resources/META-INF/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2005-2025 the original author or authors.
+Copyright 2005-2026 the original author or authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -4,7 +4,8 @@
     <variable scope="context" name="mdcPattern" value="%replace(;%X{MSGKEY};%X{MSGDATA}){';+( |$)', ''}" />
 
     <property name="LOG_TEMP" value="/tmp/owms"/>
-    <property name="MODULE_NAME" value="CORE-Admin"/>
+    <property name="MODULE_NAME" value="CORE"/>
+    <property name="SERVICE_NAME" value="Admin"/>
 
     <include resource="logback-loki.xml"/>
     <include resource="logback-appenders.xml"/>

--- a/src/test/java/org/openwms/core/admin/AdminStartupTest.java
+++ b/src/test/java/org/openwms/core/admin/AdminStartupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2025 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Closes #6

## Summary
- Snapshot builds on master only run `./mvnw verify` - artifacts are deployed to Maven Central and the site is published to gh-pages exclusively for release versions
- The GPG key is only imported into the runner when a release is published
- Workflow modernization: Maven caching via setup-java, concurrency control, timeouts, least-privilege `permissions`, PR trigger and Docker image validation (build only, no push) on branch builds, GHA layer cache for the multi-arch image push, surefire reports uploaded on build failures
- Dependabot configured for GitHub Actions and Maven (parent POM excluded)
- Separate polishing commit with source and resource cleanups after the Spring Boot 4 upgrade (#5)

## Notes
- Docker images are still built and pushed for every master build (`latest` for snapshots, version tag for releases), only Maven Central publishing is release-gated